### PR TITLE
Implement pyedtools-control package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# pyedtools-control
+
+pyedtools-control is a Python-based toolkit for teaching control systems. It provides
+canonical models, controller design helpers, simulation utilities, and convenient
+plotting functions built on top of `python-control` and `matplotlib`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,3 @@
+project = 'pyedtools-control'
+extensions = ['sphinx.ext.autodoc']
+html_theme = 'alabaster'

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -1,0 +1,5 @@
+API Reference
+=============
+
+.. automodule:: pyed_control
+    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,8 @@
+pyedtools-control
+=================
+
+.. toctree::
+   :maxdepth: 2
+
+   user_guide
+   api_reference

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -1,0 +1,4 @@
+User Guide
+==========
+
+This guide provides examples of using pyedtools-control.

--- a/pyed_control/__init__.py
+++ b/pyed_control/__init__.py
@@ -1,0 +1,10 @@
+"""pyedtools-control core package."""
+
+from . import models, controllers, simulation, plotting
+
+__all__ = [
+    'models',
+    'controllers',
+    'simulation',
+    'plotting',
+]

--- a/pyed_control/controllers.py
+++ b/pyed_control/controllers.py
@@ -1,0 +1,35 @@
+"""Controller design helpers."""
+
+from control import TransferFunction
+
+
+def make_pid(kp, ki=0.0, kd=0.0):
+    """Return a PID controller as a TransferFunction."""
+    num = [kd, kp, ki]
+    den = [1, 0]
+    return TransferFunction(num, den)
+
+
+def pid_ziegler_nichols(plant):
+    """Rudimentary Ziegler–Nichols PID tuning.
+
+    This implementation finds the ultimate gain Ku and period Tu by applying
+    a simple relay feedback approximation. Here we approximate using the
+    frequency response where the phase is -180 degrees.
+    """
+    import numpy as np
+    from control import bode
+
+    omega = np.logspace(-2, 4, 1000)
+    mag, phase, _ = bode(plant, omega, plot=False)
+    # Find frequency where phase crosses -180 degrees
+    idx = (phase <= -np.pi + 1e-3).nonzero()[0]
+    if len(idx) == 0:
+        raise ValueError("Plant does not cross -180 degrees")
+    w180 = omega[idx[0]]
+    Ku = 1.0 / mag[idx[0]]
+    Tu = 2 * np.pi / w180
+    kp = 0.6 * Ku
+    ki = 1.2 * Ku / Tu
+    kd = 3 * Ku * Tu / 40
+    return kp, ki, kd

--- a/pyed_control/matlab_import.py
+++ b/pyed_control/matlab_import.py
@@ -1,0 +1,14 @@
+"""Utilities to convert MATLAB models to python-control."""
+
+import scipy.io
+from control import ss
+
+
+def convert_matlab_ss(matfile, var='sys'):
+    """Load a MATLAB .mat file containing A, B, C, D and return StateSpace."""
+    data = scipy.io.loadmat(matfile)
+    A = data[var]['A'] if isinstance(data[var], dict) else data['A']
+    B = data[var]['B'] if isinstance(data[var], dict) else data['B']
+    C = data[var]['C'] if isinstance(data[var], dict) else data['C']
+    D = data[var]['D'] if isinstance(data[var], dict) else data['D']
+    return ss(A, B, C, D)

--- a/pyed_control/models.py
+++ b/pyed_control/models.py
@@ -1,0 +1,21 @@
+"""Pre-built physical models for control education."""
+
+from control import TransferFunction, tf
+
+
+def mass_spring_damper(m=1.0, k=1.0, b=0.2):
+    """Return the transfer function of a mass-spring-damper system.
+
+    The form is ``1/(m s^2 + b s + k)`` where ``m`` is mass, ``k`` is spring
+    constant, and ``b`` is damping coefficient.
+    """
+    num = [1.0]
+    den = [m, b, k]
+    return TransferFunction(num, den)
+
+
+def dc_motor(J=0.01, b=0.1, K=0.01, R=1.0, L=0.5):
+    """Return the transfer function of a simple DC motor."""
+    num = [K]
+    den = [L*J, L*b + R*J, R*b + K**2]
+    return TransferFunction(num, den)

--- a/pyed_control/plotting.py
+++ b/pyed_control/plotting.py
@@ -1,0 +1,37 @@
+"""Convenience plotting wrappers."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from control import step_response, bode
+
+
+def step(sys, title=None):
+    """Plot step response."""
+    t, y = step_response(sys)
+    plt.figure()
+    plt.plot(t, y)
+    plt.xlabel('Time [s]')
+    plt.ylabel('Amplitude')
+    if title:
+        plt.title(title)
+    plt.grid(True)
+    plt.show()
+
+
+def bode_plot(sys, margins=False):
+    """Plot Bode magnitude and phase."""
+    mag, phase, omega = bode(sys, dB=True, plot=False)
+    fig, (ax1, ax2) = plt.subplots(2, 1)
+    ax1.semilogx(omega, 20*np.log10(mag))
+    ax1.set_ylabel('Magnitude [dB]')
+    ax1.grid(True)
+    ax2.semilogx(omega, phase * 180 / np.pi)
+    ax2.set_ylabel('Phase [deg]')
+    ax2.set_xlabel('Frequency [rad/s]')
+    ax2.grid(True)
+    if margins:
+        from control import margin
+        gm, pm, wg, wp = margin(sys)
+        ax1.axvline(wg, color='r', linestyle='--')
+        ax2.axvline(wp, color='r', linestyle='--')
+    plt.show()

--- a/pyed_control/simulation.py
+++ b/pyed_control/simulation.py
@@ -1,0 +1,19 @@
+"""Simulation helpers built on python-control."""
+
+from control import feedback, step_response
+
+
+def feedback_loop(plant, controller=1):
+    """Return closed-loop transfer function with unity feedback."""
+    return feedback(controller*plant, 1)
+
+
+def step_info(sys):
+    """Return basic step response characteristics."""
+    import numpy as np
+    t, y = step_response(sys)
+    steady_state = y[-1]
+    overshoot = (y.max() - steady_state) / steady_state * 100 if steady_state else 0
+    settling_idx = np.where(abs(y - steady_state) <= 0.02 * abs(steady_state))[0]
+    settling_time = t[settling_idx[0]] if len(settling_idx) else t[-1]
+    return dict(overshoot=overshoot, settling_time=settling_time)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+control>=0.9.0
+numpy
+scipy
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='pyedtools-control',
+    version='0.1.0',
+    packages=find_packages(),
+    install_requires=[
+        'control>=0.9.0',
+        'numpy',
+        'scipy',
+        'matplotlib',
+    ],
+    author='PyEdTools Team',
+    description='Educational control systems toolkit',
+    license='MIT'
+)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -1,0 +1,14 @@
+import numpy as np
+from pyed_control import controllers, models
+
+
+def test_make_pid_tf():
+    C = controllers.make_pid(1.0, 0.5, 0.1)
+    assert np.allclose(C.num[0][0], [0.1, 1.0, 0.5])
+    assert np.allclose(C.den[0][0], [1.0, 0.0])
+
+
+def test_pid_ziegler_nichols_returns_tuple():
+    P = models.mass_spring_damper()
+    kp, ki, kd = controllers.pid_ziegler_nichols(P)
+    assert kp > 0 and ki > 0 and kd > 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,7 @@
+import numpy as np
+from pyed_control import models
+
+
+def test_mass_spring_damper_tf():
+    sys = models.mass_spring_damper(m=2.0, k=4.0, b=1.0)
+    assert np.allclose(sys.den[0][0], [2.0, 1.0, 4.0])

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,8 @@
+from pyed_control import models, controllers, simulation
+
+
+def test_feedback_loop_type():
+    P = models.mass_spring_damper()
+    C = controllers.make_pid(1, 1, 1)
+    T = simulation.feedback_loop(P, C)
+    assert T.ninputs == 1 and T.noutputs == 1


### PR DESCRIPTION
## Summary
- implement package skeleton for pyedtools-control
- add pre-built models (mass-spring-damper, DC motor)
- add controller helpers with Ziegler–Nichols PID tuning
- add simulation and plotting utilities
- add MATLAB import helper
- add docs scaffold and unit tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f1929c8b4832baf0591c12d6e752f